### PR TITLE
add GetServiceByRevision API

### DIFF
--- a/GetService/__tests__/handler.test.ts
+++ b/GetService/__tests__/handler.test.ts
@@ -104,9 +104,9 @@ describe("GetServiceHandler", () => {
     const aServiceId = "1" as NonEmptyString;
     const getServiceHandler = GetServiceHandler(serviceModelMock as any);
     const response = await getServiceHandler(aServiceId);
-    expect(serviceModelMock.findLastVersionByModelId).toHaveBeenCalledWith(
+    expect(serviceModelMock.findLastVersionByModelId).toHaveBeenCalledWith([
       aServiceId
-    );
+    ]);
     expect(response.kind).toBe("IResponseSuccessJson");
     if (response.kind === "IResponseSuccessJson") {
       expect(response.value).toEqual(aSeralizedService);
@@ -121,9 +121,9 @@ describe("GetServiceHandler", () => {
     const aServiceId = "1" as NonEmptyString;
     const getServiceHandler = GetServiceHandler(serviceModelMock as any);
     const response = await getServiceHandler(aServiceId);
-    expect(serviceModelMock.findLastVersionByModelId).toHaveBeenCalledWith(
+    expect(serviceModelMock.findLastVersionByModelId).toHaveBeenCalledWith([
       aServiceId
-    );
+    ]);
     expect(response.kind).toBe("IResponseErrorQuery");
   });
   it("should return not found if the service does not exist", async () => {
@@ -135,9 +135,9 @@ describe("GetServiceHandler", () => {
     const aServiceId = "1" as NonEmptyString;
     const getServiceHandler = GetServiceHandler(serviceModelMock as any);
     const response = await getServiceHandler(aServiceId);
-    expect(serviceModelMock.findLastVersionByModelId).toHaveBeenCalledWith(
+    expect(serviceModelMock.findLastVersionByModelId).toHaveBeenCalledWith([
       aServiceId
-    );
+    ]);
     expect(response.kind).toBe("IResponseErrorNotFound");
   });
 });

--- a/GetServiceByRevision/__tests__/handler.test.ts
+++ b/GetServiceByRevision/__tests__/handler.test.ts
@@ -114,7 +114,10 @@ describe("GetServiceByRevisionHandler", () => {
     const getServiceByRevisionHandler = GetServiceByRevisionHandler(
       serviceModelMock as any
     );
-    const response = await getServiceByRevisionHandler(aServiceId, aVersion);
+    const response = await getServiceByRevisionHandler(
+      aServiceId,
+      (aVersion as unknown) as NonEmptyString
+    );
     expect(serviceModelMock.getQueryIterator).toHaveBeenCalledTimes(1);
     expect(response.kind).toBe("IResponseSuccessJson");
     if (response.kind === "IResponseSuccessJson") {
@@ -139,7 +142,10 @@ describe("GetServiceByRevisionHandler", () => {
     const getServiceByRevisionHandler = GetServiceByRevisionHandler(
       serviceModelMock as any
     );
-    const response = await getServiceByRevisionHandler(aServiceId, aVersion);
+    const response = await getServiceByRevisionHandler(
+      aServiceId,
+      (aVersion as unknown) as NonEmptyString
+    );
     expect(serviceModelMock.getQueryIterator).toHaveBeenCalledTimes(1);
     expect(response.kind).toBe("IResponseErrorQuery");
   });
@@ -160,7 +166,7 @@ describe("GetServiceByRevisionHandler", () => {
     );
     const response = await getServiceByRevisionHandler(
       aServiceId,
-      999 as NonNegativeInteger
+      (999 as unknown) as NonEmptyString
     );
     expect(serviceModelMock.getQueryIterator).toHaveBeenCalledTimes(1);
     expect(response.kind).toBe("IResponseErrorNotFound");

--- a/GetServiceByRevision/function.json
+++ b/GetServiceByRevision/function.json
@@ -1,0 +1,20 @@
+{
+  "bindings": [
+    {
+      "authLevel": "function",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req",
+      "route": "v1/services/{serviceid}/revision/{version}",
+      "methods": [
+        "get"
+      ]
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "res"
+    }
+  ],
+  "scriptFile": "../dist/GetServiceByRevision/index.js"
+}

--- a/GetServiceByRevision/function.json
+++ b/GetServiceByRevision/function.json
@@ -5,7 +5,7 @@
       "type": "httpTrigger",
       "direction": "in",
       "name": "req",
-      "route": "v1/services/{serviceid}/revision/{version}",
+      "route": "v1/services/{serviceid}/revisions/{version}",
       "methods": [
         "get"
       ]

--- a/GetServiceByRevision/index.ts
+++ b/GetServiceByRevision/index.ts
@@ -24,7 +24,8 @@ const serviceModel = new ServiceModel(
 );
 
 app.get(
-  "/api/v1/services/:serviceid/revision/:version",
+  "/api/v1/services/:serviceid/revisions/:version",
+
   GetServiceByRevision(serviceModel)
 );
 

--- a/GetServiceByRevision/index.ts
+++ b/GetServiceByRevision/index.ts
@@ -1,0 +1,39 @@
+import { Context } from "@azure/functions";
+
+import * as express from "express";
+
+import {
+  SERVICE_COLLECTION_NAME,
+  ServiceModel
+} from "io-functions-commons/dist/src/models/service";
+
+import { secureExpressApp } from "io-functions-commons/dist/src/utils/express";
+import { setAppContext } from "io-functions-commons/dist/src/utils/middlewares/context_middleware";
+
+import createAzureFunctionHandler from "io-functions-express/dist/src/createAzureFunctionsHandler";
+
+import { cosmosdbInstance } from "../utils/cosmosdb";
+import { GetServiceByRevision } from "./handler";
+
+// Setup Express
+const app = express();
+secureExpressApp(app);
+
+const serviceModel = new ServiceModel(
+  cosmosdbInstance.container(SERVICE_COLLECTION_NAME)
+);
+
+app.get(
+  "/api/v1/services/:serviceid/revision/:version",
+  GetServiceByRevision(serviceModel)
+);
+
+const azureFunctionHandler = createAzureFunctionHandler(app);
+
+// Binds the express app to an Azure Function handler
+function httpStart(context: Context): void {
+  setAppContext(app, context);
+  azureFunctionHandler(context);
+}
+
+export default httpStart;

--- a/openapi/index.yaml
+++ b/openapi/index.yaml
@@ -63,10 +63,42 @@ paths:
               service_id: 2b3e728c1a5d1efa035c
               service_name: service
               version: 1
-        "401":
-          description: Unauthorized
         "404":
           description: No service found for the provided ID.
+        "429":
+          description: Too many requests
+  "/services/{service_id}/revision/{version}":
+    get:
+      operationId: getServiceByRevision
+      summary: GetService by a given version
+      description: A previously created service with the provided service ID and version is returned.
+      tags:
+        - restricted
+      parameters:
+        - name: service_id
+          in: path
+          type: string
+          required: true
+          description: The ID of an existing Service.
+        - name: version
+          in: path
+          type: string
+          required: true
+          description: The version of an existing Service.
+      responses:
+        "200":
+          description: Service found.
+          schema:
+            "$ref": "#/definitions/ServicePublic"
+          examples:
+            application/json:
+              department_name: dept
+              organization_name: org
+              service_id: 2b3e728c1a5d1efa035c
+              service_name: service
+              version: 1
+        "404":
+          description: No service found for the provided ID and version.
         "429":
           description: Too many requests
 consumes:

--- a/openapi/index.yaml
+++ b/openapi/index.yaml
@@ -67,7 +67,7 @@ paths:
           description: No service found for the provided ID.
         "429":
           description: Too many requests
-  "/services/{service_id}/revision/{version}":
+  "/services/{service_id}/revisions/{version}":
     get:
       operationId: getServiceByRevision
       summary: GetService by a given version


### PR DESCRIPTION
This PR contains a new API, that returns a Service by providing its `serviceId` and `version`.
Also removed deprecated method's usage `findOneServiceById`.