### PR TITLE
[#175119553] Centralize environment variables in single config module

### DIFF
--- a/GetVisibleServices/index.ts
+++ b/GetVisibleServices/index.ts
@@ -3,7 +3,6 @@ import { createBlobService } from "azure-storage";
 
 import * as express from "express";
 
-import { getRequiredStringEnv } from "io-functions-commons/dist/src/utils/env";
 import { secureExpressApp } from "io-functions-commons/dist/src/utils/express";
 import { setAppContext } from "io-functions-commons/dist/src/utils/middlewares/context_middleware";
 
@@ -11,12 +10,15 @@ import createAzureFunctionHandler from "io-functions-express/dist/src/createAzur
 
 import { GetVisibleServices } from "./handler";
 
+import { getConfigOrThrow } from "../utils/config";
+
+const config = getConfigOrThrow();
+
 // Setup Express
 const app = express();
 secureExpressApp(app);
 
-const storageConnectionString = getRequiredStringEnv("CachedStorageConnection");
-const blobService = createBlobService(storageConnectionString);
+const blobService = createBlobService(config.CachedStorageConnection);
 
 app.get("/services", GetVisibleServices(blobService));
 

--- a/utils/config.ts
+++ b/utils/config.ts
@@ -1,0 +1,51 @@
+/**
+ * Config module
+ *
+ * Single point of access for the application confguration. Handles validation on required environment variables.
+ * The configuration is evaluate eagerly at the first access to the module. The module exposes convenient methods to access such value.
+ */
+
+import * as t from "io-ts";
+import { readableReport } from "italia-ts-commons/lib/reporters";
+import { NonEmptyString } from "italia-ts-commons/lib/strings";
+
+// global app configuration
+export type IConfig = t.TypeOf<typeof IConfig>;
+export const IConfig = t.interface({
+  COSMOSDB_KEY: NonEmptyString,
+  COSMOSDB_NAME: NonEmptyString,
+  COSMOSDB_URI: NonEmptyString,
+
+  CachedStorageConnection: NonEmptyString,
+
+  isProduction: t.boolean
+});
+
+// No need to re-evaluate this object for each call
+const errorOrConfig: t.Validation<IConfig> = IConfig.decode({
+  ...process.env,
+  isProduction: process.env.NODE_ENV === "production"
+});
+
+/**
+ * Read the application configuration and check for invalid values.
+ * Configuration is eagerly evalued when the application starts.
+ *
+ * @returns either the configuration values or a list of validation errors
+ */
+export function getConfig(): t.Validation<IConfig> {
+  return errorOrConfig;
+}
+
+/**
+ * Read the application configuration and check for invalid values.
+ * If the application is not valid, raises an exception.
+ *
+ * @returns the configuration values
+ * @throws validation errors found while parsing the application configuration
+ */
+export function getConfigOrThrow(): IConfig {
+  return errorOrConfig.getOrElseL(errors => {
+    throw new Error(`Invalid configuration: ${readableReport(errors)}`);
+  });
+}

--- a/utils/cosmosdb.ts
+++ b/utils/cosmosdb.ts
@@ -2,12 +2,15 @@
  * Use a singleton CosmosDB client across functions.
  */
 import { CosmosClient } from "@azure/cosmos";
-import { getRequiredStringEnv } from "io-functions-commons/dist/src/utils/env";
+
+import { getConfigOrThrow } from "../utils/config";
+
+const config = getConfigOrThrow();
 
 // Setup DocumentDB
-export const cosmosDbUri = getRequiredStringEnv("COSMOSDB_URI");
-export const cosmosDbName = getRequiredStringEnv("COSMOSDB_NAME");
-export const cosmosDbKey = getRequiredStringEnv("COSMOSDB_KEY");
+export const cosmosDbUri = config.COSMOSDB_URI;
+export const cosmosDbName = config.COSMOSDB_NAME;
+export const cosmosDbKey = config.COSMOSDB_KEY;
 
 export const cosmosdbClient = new CosmosClient({
   endpoint: cosmosDbUri,


### PR DESCRIPTION
This PR introduces the utils/config module which aims to be the unique interface for application configuration.

Every place in which the application used to directly access env variable has been refactored to use this module instead.