### PR TITLE
[#175595000] Fix visible services by scope proxy

### DIFF
--- a/proxies.json
+++ b/proxies.json
@@ -20,7 +20,7 @@
         "methods": ["GET"],
         "route": "/services/servicesByScope.json"
       },
-      "backendUri": "https://%STATIC_WEB_ASSETS_ENDPOINT%/services/servicesByScope.json"
+      "backendUri": "https://%STATIC_WEB_ASSETS_ENDPOINT%/services/visible-services-by-scope.json"
     },
     "contextualHelp":{
       "matchCondition": {


### PR DESCRIPTION
This PR contains a fix on `servicesByScope` proxy. It must point to a static json file produced by a scheduled functions in io-functions-admin (`visible-services-by-scope.json`).