### PR TITLE
[#175595000] Hotfix storage Endpoint

### DIFF
--- a/proxies.json
+++ b/proxies.json
@@ -20,7 +20,7 @@
         "methods": ["GET"],
         "route": "/services/servicesByScope.json"
       },
-      "backendUri": "https://%STATIC_WEB_ASSETS_ENDPOINT%/services/visible-services-by-scope.json"
+      "backendUri": "https://%STATIC_BLOB_ASSETS_ENDPOINT%/services/visible-services-by-scope.json"
     },
     "contextualHelp":{
       "matchCondition": {


### PR DESCRIPTION
Changed storage endpoint on `servicesByScope` proxy from `STATIC_WEB_ASSETS_ENDPOINT` to `STATIC_BLOB_ASSETS_ENDPOINT`