### PR TITLE
[#175911484] Allow ABI logos proxy

### DIFF
--- a/proxies.json
+++ b/proxies.json
@@ -49,7 +49,13 @@
         "route": "/logos/organizations/{orgFiscalCode}.png"
       },
       "backendUri": "https://%STATIC_BLOB_ASSETS_ENDPOINT%/services/{orgFiscalCode}.png"
+    },
+    "abiLogos":{
+      "matchCondition": {
+        "methods": ["GET"],
+        "route": "/logos/abi/{abiCode}.png"
+      },
+      "backendUri": "https://%STATIC_WEB_ASSETS_ENDPOINT%/logos/abi/{abiCode}.png"
     }
-  
   }
 }


### PR DESCRIPTION
This PR introduces a new proxy rule in order to serve static Abi logo's images.