### PR TITLE
Remove url check

### DIFF
--- a/utils/healthcheck.ts
+++ b/utils/healthcheck.ts
@@ -111,18 +111,6 @@ export const checkAzureStorageHealth = (
     .map(_ => true);
 
 /**
- * Check a url is reachable
- *
- * @param url url to connect with
- *
- * @returns either true or an array of error messages
- */
-export const checkUrlHealth = (url: string): HealthCheck<"Url", true> =>
-  tryCatch(() => fetch(url, { method: "HEAD" }), toHealthProblems("Url")).map(
-    _ => true
-  );
-
-/**
  * Execute all the health checks for the application
  *
  * @returns either true or an array of error messages
@@ -139,9 +127,7 @@ export const checkApplicationHealth = (): HealthCheck<ProblemSource, true> =>
         Array<TaskEither<ReadonlyArray<HealthProblem<ProblemSource>>, true>>
       >(
         checkAzureCosmosDbHealth(config.COSMOSDB_URI, config.COSMOSDB_KEY),
-        checkAzureStorageHealth(config.CachedStorageConnection),
-        checkUrlHealth(config.STATIC_BLOB_ASSETS_ENDPOINT),
-        checkUrlHealth(config.STATIC_WEB_ASSETS_ENDPOINT)
+        checkAzureStorageHealth(config.CachedStorageConnection)
       )
     )
     .map(_ => true);


### PR DESCRIPTION
We remove the check on static assets storage's url because:
1. formal url check fails because variables are intended to contain url without protocol
2. a `HEAD` directly to the root path of the storage would not succeed (404 error)

We need to reason more on how to perform these checks. Meanwhile, we remove it.