### PR TITLE
[#ENTE-75] Email static assets route

### DIFF
--- a/proxies.json
+++ b/proxies.json
@@ -77,6 +77,13 @@
         "route": "/spid/idps/{*path}"
       },
       "backendUri": "https://%STATIC_WEB_ASSETS_ENDPOINT%/spid/idps/{path}"
+    },
+    "emailAssets":{
+      "matchCondition": {
+        "methods": ["GET"],
+        "route": "/email-assets/{*path}"
+      },
+      "backendUri": "https://%STATIC_WEB_ASSETS_ENDPOINT%/email-assets/{path}"
     }
   }
 }


### PR DESCRIPTION
We need to send a mailing list with inline images so we created a new main level directory at io-services-metadata and here the relative route.