### PR TITLE
Add zendesk proxy route

### DIFF
--- a/proxies.json
+++ b/proxies.json
@@ -85,7 +85,7 @@
       },
       "backendUri": "https://%STATIC_WEB_ASSETS_ENDPOINT%/email-assets/{path}"
     },
-    "zendesk":{
+    "assistanceTools":{
       "matchCondition": {
         "methods": ["GET"],
         "route": "/assistanceTools/{*path}"

--- a/proxies.json
+++ b/proxies.json
@@ -84,6 +84,13 @@
         "route": "/email-assets/{*path}"
       },
       "backendUri": "https://%STATIC_WEB_ASSETS_ENDPOINT%/email-assets/{path}"
+    },
+    "zendesk":{
+      "matchCondition": {
+        "methods": ["GET"],
+        "route": "/assistanceTools/{*path}"
+      },
+      "backendUri": "https://%STATIC_WEB_ASSETS_ENDPOINT%/assistanceTools/{path}"
     }
   }
 }


### PR DESCRIPTION
Since [this asset](https://github.com/pagopa/io-services-metadata/blob/master/assistanceTools/zendesk.json) has been added in [io-services-metadata](https://github.com/pagopa/io-services-metadata), it should be accessible through the CDN