### PR TITLE
Add eucovidcert logo path

### DIFF
--- a/proxies.json
+++ b/proxies.json
@@ -64,6 +64,13 @@
       },
       "backendUri": "https://%STATIC_WEB_ASSETS_ENDPOINT%/logos/abi/{abiCode}.png"
     },
+    "eucovidCertLogos":{
+      "matchCondition": {
+        "methods": ["GET"],
+        "route": "/logos/eucovidcert/{logoName}.png"
+      },
+      "backendUri": "https://%STATIC_WEB_ASSETS_ENDPOINT%/logos/eucovidcert/{logoName}.png"
+    },
     "privative":{
       "matchCondition": {
         "methods": ["GET"],


### PR DESCRIPTION
This PR adds the path to serve eucovidcert logos via CDN

see https://github.com/pagopa/io-services-metadata/pull/542