### PR TITLE
Added a route to serve external apps logos

### DIFF
--- a/proxies.json
+++ b/proxies.json
@@ -64,6 +64,13 @@
       },
       "backendUri": "https://%STATIC_WEB_ASSETS_ENDPOINT%/logos/abi/{abiCode}.png"
     },
+    "appLogos":{
+      "matchCondition": {
+        "methods": ["GET"],
+        "route": "/logos/apps/{appName}.png"
+      },
+      "backendUri": "https://%STATIC_WEB_ASSETS_ENDPOINT%/logos/apps/{appName}.png"
+    },
     "eucovidCertLogos":{
       "matchCondition": {
         "methods": ["GET"],


### PR DESCRIPTION
Since this asset has been added in io-services-metadata, it should be accessible through the CDN