### PR TITLE
[IA-689] Include new html path for static pages

### DIFF
--- a/proxies.json
+++ b/proxies.json
@@ -43,6 +43,13 @@
       },
       "backendUri": "https://%STATIC_WEB_ASSETS_ENDPOINT%/bonus/{path}"
     },
+    "html":{
+      "matchCondition": {
+        "methods": ["GET"],
+        "route": "/html/{page}"
+      },
+      "backendUri": "https://%STATIC_WEB_ASSETS_ENDPOINT%/html/{page}"
+    },
     "serviceLogos":{
       "matchCondition": {
         "methods": ["GET"],


### PR DESCRIPTION
#### List of Changes
Add a new path for static assets under `/html/{page}`. The new folder `html` is reserved for static HTML5 pages.

#### Motivation and Context
Within the project _prj_donazioni_ the app fetches a static page from the CDN.

#### How Has This Been Tested?
Please note that I **don't know** how to test this code without merging it. Open to suggestions 🙇 .

Wrt the app, we tested this behavior thoroughy via [io-dev-server](https://github.com/pagopa/io-dev-api-server/pull/145).
The app fetches a static page from the CDN and renders it in a webview.

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
